### PR TITLE
Issue15 matthew mizielinski CVs and tables fixes

### DIFF
--- a/Tables/SNAPSI_6hr.json
+++ b/Tables/SNAPSI_6hr.json
@@ -1,16 +1,16 @@
 {
     "Header": {
-        "data_specs_version": "0.9.2",
+        "data_specs_version": "0.9.3",
         "cmor_version": "3.5",
-        "table_id": "6hr",
+        "table_id": "Table 6hr",
         "realm": "atmos",
-        "table_date": "August 25, 2021",
+        "table_date": "August 23, 2022",
         "missing_value": "1e20",
         "int_missing_value": "-999",
         "product": "model-output",
         "approx_interval": "1.00000",
         "generic_levels": "",
-        "mip_era": "CMIP6",
+        "mip_era": "SNAPSI",
         "Conventions": "CF-1.8 SNAP"
     },
     "variable_entry": {

--- a/Tables/SNAPSI_6hrPt.json
+++ b/Tables/SNAPSI_6hrPt.json
@@ -1,16 +1,16 @@
 {
     "Header": {
-        "data_specs_version": "0.9.2",
+        "data_specs_version": "0.9.3",
         "cmor_version": "3.5",
-        "table_id": "6hrPt",
+        "table_id": "Table 6hrPt",
         "realm": "atmos",
-        "table_date": "August 25, 2021",
+        "table_date": "August 23, 2022",
         "missing_value": "1e20",
         "int_missing_value": "-999",
         "product": "model-output",
         "approx_interval": "1.00000",
         "generic_levels": "",
-        "mip_era": "CMIP6",
+        "mip_era": "SNAPSI",
         "Conventions": "CF-1.8 SNAP"
     },
     "variable_entry": {

--- a/Tables/SNAPSI_6hrPtZ.json
+++ b/Tables/SNAPSI_6hrPtZ.json
@@ -1,16 +1,16 @@
 {
     "Header": {
-        "data_specs_version": "0.9.2",
+        "data_specs_version": "0.9.3",
         "cmor_version": "3.5",
-        "table_id": "6hrPtZ",
+        "table_id": "Table 6hrPtZ",
         "realm": "atmos",
-        "table_date": "August 25, 2021",
+        "table_date": "August 23, 2023",
         "missing_value": "1e20",
         "int_missing_value": "-999",
         "product": "model-output",
         "approx_interval": "1.00000",
         "generic_levels": "",
-        "mip_era": "CMIP6",
+        "mip_era": "SNAPSI",
         "Conventions": "CF-1.8 SNAP"
     },
     "variable_entry": {

--- a/Tables/SNAPSI_6hrRef.json
+++ b/Tables/SNAPSI_6hrRef.json
@@ -1,16 +1,16 @@
 {
     "Header": {
-        "data_specs_version": "0.9.2",
+        "data_specs_version": "0.9.3",
         "cmor_version": "3.5",
-        "table_id": "6hrRef",
+        "table_id": "Table 6hrRef",
         "realm": "atmos",
-        "table_date": "August 25, 2021",
+        "table_date": "August 23, 2022",
         "missing_value": "1e20",
         "int_missing_value": "-999",
         "product": "model-output",
         "approx_interval": "1.00000",
         "generic_levels": "",
-        "mip_era": "CMIP6",
+        "mip_era": "SNAPSI",
         "Conventions": "CF-1.8 SNAP"
     },
     "variable_entry": {

--- a/Tables/SNAPSI_6hrZ.json
+++ b/Tables/SNAPSI_6hrZ.json
@@ -1,16 +1,16 @@
 {
     "Header": {
-        "data_specs_version": "0.9.2",
+        "data_specs_version": "0.9.3",
         "cmor_version": "3.5",
-        "table_id": "6hrZ",
+        "table_id": "Table 6hrZ",
         "realm": "atmos",
-        "table_date": "August 25, 2021",
+        "table_date": "August 23, 2022",
         "missing_value": "1e20",
         "int_missing_value": "-999",
         "product": "model-output",
         "approx_interval": "1.00000",
         "generic_levels": "",
-        "mip_era": "CMIP6",
+        "mip_era": "SNAPSI",
         "Conventions": "CF-1.8 SNAP"
     },
     "variable_entry": {

--- a/Tables/SNAPSI_CV.json
+++ b/Tables/SNAPSI_CV.json
@@ -25,8 +25,8 @@
             "variant_label"
         ],
         "version_metadata": {
-            "CV_collection_modified": "August 25, 2021",
-            "CV_collection_version": "0.9.2",
+            "CV_collection_modified": "August 23, 2022",
+            "CV_collection_version": "0.9.3",
             "author": "Peter Hitchcock <aph28@cornell.edu>"
         },
         "activity_id": {
@@ -209,10 +209,10 @@
             "6hrRef"
         ],
         "license": [
-            "^SNAPSI model data produced by .* is licensed under a Creative Commons Attribution.*ShareAlike 4.0 International License .https://creativecommons.org/licenses.* *Consult _ for terms of use governing SNAPSI output, including citation requirements and proper acknowledgment\\. *The data producers and data providers make no warranty, either express or implied, including, but not limited to, warranties of merchantability and fitness for a particular purpose\\. *All liabilities arising from the supply of the information (including any liability arising in negligence) are excluded to the fullest extent permitted by law\\.$"
+            "^SNAPSI model data produced by .* is licensed under a Creative Commons Attribution ShareAlike 4.0 International License https://creativecommons.org/licenses Consult _ for terms of use governing SNAPSI output, including citation requirements and proper acknowledgment\\. The data producers and data providers make no warranty, either express or implied, including, but not limited to, warranties of merchantability and fitness for a particular purpose\\. All liabilities arising from the supply of the information (including any liability arising in negligence) are excluded to the fullest extent permitted by law\\.$"
         ],
         "mip_era": [
-            "CMIP6"
+            "SNAPSI"
         ],
         "sub_experiment_id": {
             "s20180125": "Forecasts initialized on or near 2018-01-25",
@@ -225,46 +225,51 @@
         },
         "experiment_id": {
             "free": {
-                "activity_id": "SNAPSI",
+                "activity_id": ["SNAPSI"],
+                "additional_allowed_model_components": ["AOGCM", "AER"],
                 "experiment": "Free-running ensemble forecast",
                 "experiment_id": "free",
-                "parent_experiment_id": "no parent",
+                "parent_experiment_id": ["no parent"],
                 "sub_experiment_id": [
                     "s20180125", "s20180208", "s20181213", "s20190108", "s20190829", "s20191001"
                 ]
             },
             "control": {
-                "activity_id": "SNAPSI",
+                "activity_id": ["SNAPSI"],
+                "additional_allowed_model_components": ["AOGCM", "AER"],
                 "experiment": "Ensemble forecast with zonally symmetric component of stratosphere nudged to climatology",
                 "experiment_id": "control",
-                "parent_experiment_id": "no parent",
+                "parent_experiment_id": ["no parent"],
                 "sub_experiment_id": [
                     "sref", "s20180125", "s20180208", "s20181213", "s20190108", "s20190829", "s20191001"
                 ]
             },
             "control-full": {
-                "activity_id": "SNAPSI",
+                "activity_id": ["SNAPSI"],
+                "additional_allowed_model_components": ["AOGCM", "AER"],
                 "experiment": "Ensemble forecast with stratosphere nudged to climatology",
                 "experiment_id": "control-full",
-                "parent_experiment_id": "no parent",
+                "parent_experiment_id": ["no parent"],
                 "sub_experiment_id": [
                     "sref", "s20180125", "s20180208", "s20181213", "s20190108", "s20190829", "s20191001"
                 ]
             },
             "nudged": {
-                "activity_id": "SNAPSI",
+                "activity_id": ["SNAPSI"],
+		"additional_allowed_model_components": ["AOGCM", "AER"],
                 "experiment": "Ensemble forecast with zonally symmetric component of stratosphere nudged to reanalyzed evolution",
                 "experiment_id": "nudged",
-                "parent_experiment_id": "no parent",
+                "parent_experiment_id": ["no parent"],
                 "sub_experiment_id": [
                     "sref", "s20180125", "s20180208", "s20181213", "s20190108", "s20190829", "s20191001", "sref"
                 ]
             },
             "nudged-full": {
-                "activity_id": "SNAPSI",
+                "activity_id": ["SNAPSI"],
+                "additional_allowed_model_components": ["AOGCM", "AER"],
                 "experiment": "Ensemble forecast with stratosphere nudged to reanalyzed evolution",
                 "experiment_id": "nudged-full",
-                "parent_experiment_id": "no parent",
+                "parent_experiment_id": ["no parent"],
                 "sub_experiment_id": [
                     "sref", "s20180125", "s20180208", "s20181213", "s20190108", "s20190829", "s20191001", "sref"
                 ]
@@ -274,7 +279,7 @@
             "model-output"
         ],
         "tracking_id": [
-            "<uuid>"
+            ".*"
         ],
         "realization_index": [
             "^\\[\\{0,\\}[[:digit:]]\\{1,\\}\\]\\{0,\\}$"
@@ -283,7 +288,7 @@
             "r[[:digit:]]\\{1,\\}i[[:digit:]]\\{1,\\}p[[:digit:]]\\{1,\\}f[[:digit:]]\\{1,\\}$"
         ],
         "data_specs_version": [
-            "^[[:digit:]]\\{2,2\\}\\.[[:digit:]]\\{2,2\\}\\.[[:digit:]]\\{2,2\\}$"
+            "^[[:digit:]]\\{1,2\\}\\.[[:digit:]]\\{1,2\\}\\.[[:digit:]]\\{1,2\\}$"
         ],
         "Conventions": [
             "CF-1.8 SNAP"

--- a/Tables/SNAPSI_CV.json
+++ b/Tables/SNAPSI_CV.json
@@ -279,7 +279,7 @@
             "model-output"
         ],
         "tracking_id": [
-            ".*"
+            "SNAPSI/.*"
         ],
         "realization_index": [
             "^\\[\\{0,\\}[[:digit:]]\\{1,\\}\\]\\{0,\\}$"

--- a/Tables/SNAPSI_coordinate.json
+++ b/Tables/SNAPSI_coordinate.json
@@ -637,7 +637,31 @@
                "3.8841625",
                "2.551303",
                "1.5002737"
-            ], 
+            ]
+        },
+	"sdepth1": {
+                "standard_name": "depth",
+                "units": "m",
+                "axis": "Z",
+                "long_name": "depth",
+                "climatology": "",
+                "formula": "",
+                "must_have_bounds": "yes",
+                "out_name": "depth",
+                "positive": "down",
+                "requested": "",
+                "requested_bounds": "",
+                "stored_direction": "increasing",
+                "tolerance": "",
+                "type": "double",
+                "valid_max": "0.1",
+                "valid_min": "0.0",
+                "value": "0.05",
+                "z_bounds_factors": "",
+                "z_factors": "",
+                "bounds_values": "0.0 0.1",
+                "generic_level_name": ""
+        }, 
         "standard_hybrid_sigma": {
             "standard_name": "atmosphere_hybrid_sigma_pressure_coordinate", 
             "units": "1", 

--- a/Tables/SNAPSI_grids.json
+++ b/Tables/SNAPSI_grids.json
@@ -1,12 +1,12 @@
 {
     "Header": {
-        "data_specs_version": "01.00.00", 
+        "data_specs_version": "0.9.3", 
         "table_id": "Table grids", 
         "cmor_version": "3.5", 
-        "table_date": "18 November 2020", 
+        "table_date": "August 23, 2022", 
         "missing_value": "1e20", 
         "product": "output", 
-        "Conventions": "CF-1.7 CMIP-6.2"
+        "Conventions": "CF-1.8 SNAP"
     }, 
     "mapping_entry": {
         "sample_user_mapping": {


### PR DESCRIPTION
Changes I've made to get this past CMOR:
* Inserted "Table" prefix into `table_id` in every MIP table 
* Changed `mip_era` from "CMIP6" to "SNAPSI" everywhere (CMOR will look for tables & CVs named "CMIP6_*" otherwise)
* Experiment definitions, 
   * The `activity_id` and `parent_experiment_id` fields need to be lists
   * I've added a list of `allowed_model_components` with a default of `AOGCM` and `AER`. The `required_model_components` can also be used if there are requirements on experiments.
* `SNAPSI_coordinate.json` was invalid as the entry for the plev137 pressure level set was not closed properly. Note that this entry may be missing a number of required fields.  
* coordinate set was also missing `sdepth1` dimension which is used in `mrsos` in the `6hrPt` table.
* Set `Conventions` field in the grids definition table to be consistent with else where.

Other changes:
* Updated `data_specs_version` to `0.9.3` and ensured that this format is allowed by the CVs 
* Updated `table_date` consistently to today's date
* Simplified license pattern -- have a careful look at the license you are using as this pattern is painful to get correct. CMIP6 caused itself some issues by using the ShareAlike license.  
*  `tracking_id` pattern in CVs set to `SNAPSI/.*`  -- CMOR doesn't like absent prefixes and it needs to include the `.*` pattern.

A number of the above should be reviewed and possibly altered depending on your purposes. In particular the use of `allowed_model_components` / `required_model_components` in the experiment definitions, the `plev137` pressure level entry and the license pattern should be considered further. 

P.S. The edits to the CVs were made a little crudely. Might be worth pushing through the JSON library to get a cleaner structure (`python -m json.tool <input file>` would clean this up).